### PR TITLE
loading OAuth request without handling cookies

### DIFF
--- a/DOUSNSSharing/DOUSNSSharing/Source/Core/Base/DOUOAuth2AuthorizationService.m
+++ b/DOUSNSSharing/DOUSNSSharing/Source/Core/Base/DOUOAuth2AuthorizationService.m
@@ -56,9 +56,10 @@
     [params setObject:@"mobile" forKey:@"display"];
   }
   urlString = [urlString URLStringByAddingParameters:params];
-  NSURLRequest *request = nil;
+  NSMutableURLRequest *request = nil;
   if (params) {
-    request = [NSURLRequest requestWithURL:[NSURL URLWithString:urlString]];
+    request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString]];
+    [request setHTTPShouldHandleCookies:NO];
   }
   
   UIWebView *authorizationWebView = [[UIWebView alloc] init];


### PR DESCRIPTION
人人网会用 cookie 记录登录信息，导致在授权之后再次授权的时候，没有出现输入用户名密码的页面，而是直接授权获得 authorization code。

已经测试了人人之外的其他几个授权功能，都没有问题。
